### PR TITLE
replace API_BASE_LINK with proper implementation

### DIFF
--- a/src/components/page_components/study_plans/StudyPlanTable.tsx
+++ b/src/components/page_components/study_plans/StudyPlanTable.tsx
@@ -5,14 +5,14 @@ import { StudyPlanElement } from "@ourtypes/study_plans_page_types/StudyPlanElem
 import { useState } from "react";
 import { FaDownload, FaEye, FaSearch } from "react-icons/fa";
 import { StudyPlanTableRowsTemplate } from "./StudyPlanTableRowsTemplate";
-import { API_BASE_LINK } from "@utils/constants/API_BASE_LINK";
 
 interface StudyPlanTableProps {
+	API_BASE_LINK: string;
 	elements: StudyPlanElement[];
 }
 
 // XD
-async function downloadFile(element: StudyPlanElement) {
+async function downloadFile(API_BASE_LINK: string, element: StudyPlanElement) {
 	const fileUrl = `${API_BASE_LINK}/api/files/${element.fileKey}?download=true`;
 
 	try {
@@ -36,7 +36,7 @@ async function downloadFile(element: StudyPlanElement) {
 	}
 }
 
-export function StudyPlanTable({ elements }: StudyPlanTableProps) {
+export function StudyPlanTable({ elements, API_BASE_LINK }: StudyPlanTableProps) {
 	const [values, handlers] = useListState(elements);
 	const [searchString, setSearchString] = useDebouncedState("", 500);
 
@@ -56,7 +56,7 @@ export function StudyPlanTable({ elements }: StudyPlanTableProps) {
 		const checkedStudyPlanElements = getAllCheckedStudyPlanElements();
 
 		for (const element of checkedStudyPlanElements) {
-			await downloadFile(element);
+			await downloadFile(API_BASE_LINK, element);
 		}
 
 		setDownloading(false);

--- a/src/pages/resources.tsx
+++ b/src/pages/resources.tsx
@@ -5,9 +5,10 @@ import { useDebouncedValue, useDisclosure } from "@mantine/hooks";
 import { Resource } from "@ourtypes/resources_page_types/ResourceTypes";
 import { useEffect, useState } from "react";
 
-import { API_BASE_LINK } from "@utils/constants/API_BASE_LINK";
+import withAPIBaseLink from "@utils/withAPIBaseLink";
+import { InferGetServerSidePropsType } from "next";
 
-export default function ResourcesPage() {
+export default function ResourcesPage({ API_BASE_LINK }: InferGetServerSidePropsType<typeof getServerSideProps>) {
 	const [resourceList, setResourceList] = useState<Resource[]>([]);
 	const [searchQuery, setSearchQuery] = useState("");
 
@@ -17,7 +18,7 @@ export default function ResourcesPage() {
 				setResourceList(data);
 			});
 		});
-	}, []);
+	}, [API_BASE_LINK]);
 
 	const [selectedResource, setSelectedResource] = useState(resourceList[0]);
 	const [isDrawerOpen, { open: openDrawer, close: closeDrawer }] = useDisclosure(false);
@@ -66,3 +67,5 @@ export default function ResourcesPage() {
 		</div>
 	);
 }
+
+export const getServerSideProps = withAPIBaseLink();

--- a/src/pages/study_plans.tsx
+++ b/src/pages/study_plans.tsx
@@ -21,8 +21,6 @@ async function fetcher(url: string): Promise<StudyPlanElement[]> {
 }
 
 export default function StudyPlansPage({ API_BASE_LINK }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-	console.log("Base link:", API_BASE_LINK);
-
 	const { data, error, isLoading } = useSWR(`${API_BASE_LINK}/api/resources/study_plans`, fetcher);
 	const [faculties, setFaculties] = useState(new Map<string, StudyPlanElement[]>());
 

--- a/src/pages/study_plans.tsx
+++ b/src/pages/study_plans.tsx
@@ -6,8 +6,9 @@ import { useEffect, useState } from "react";
 
 import Image from "next/image";
 
+import withAPIBaseLink from "@utils/withAPIBaseLink";
+import { InferGetServerSidePropsType } from "next";
 import useSWR from "swr";
-import { API_BASE_LINK } from "@utils/constants/API_BASE_LINK";
 
 async function fetcher(url: string): Promise<StudyPlanElement[]> {
 	const response = await fetch(url);
@@ -19,7 +20,9 @@ async function fetcher(url: string): Promise<StudyPlanElement[]> {
 	return response.json();
 }
 
-export default function StudyPlansPage() {
+export default function StudyPlansPage({ API_BASE_LINK }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+	console.log("Base link:", API_BASE_LINK);
+
 	const { data, error, isLoading } = useSWR(`${API_BASE_LINK}/api/resources/study_plans`, fetcher);
 	const [faculties, setFaculties] = useState(new Map<string, StudyPlanElement[]>());
 
@@ -80,7 +83,7 @@ export default function StudyPlansPage() {
 
 						{Array.from(faculties.entries()).map(([faculty, elements]) => (
 							<Tabs.Panel key={"tabpanel" + faculty} value={faculty} pt="xs">
-								<StudyPlanTable elements={elements} />
+								<StudyPlanTable API_BASE_LINK={API_BASE_LINK} elements={elements} />
 							</Tabs.Panel>
 						))}
 					</Tabs>
@@ -89,3 +92,5 @@ export default function StudyPlansPage() {
 		</div>
 	);
 }
+
+export const getServerSideProps = withAPIBaseLink();

--- a/src/utils/constants/API_BASE_LINK.ts
+++ b/src/utils/constants/API_BASE_LINK.ts
@@ -1,3 +1,0 @@
-// TODO: Make the env files .env.local and .env.production.local or w/e
-export const API_BASE_LINK =
-	process.env.APP_ENV === "production" ? "https://center-be.stamford.dev" : "https://center-be-beta.stamford.dev";

--- a/src/utils/withAPIBaseLink.ts
+++ b/src/utils/withAPIBaseLink.ts
@@ -1,0 +1,37 @@
+// utils/withApiBaseLink.ts
+
+import { GetServerSideProps, GetServerSidePropsResult } from "next";
+
+type ApiLinkProps = {
+	API_BASE_LINK: string;
+};
+
+// Type for the higher-order function which may take an optional GetServerSideProps function
+type WithAPIBaseLink = <P extends {} = {}>(
+	getServerSidePropsFunc?: GetServerSideProps<P>,
+) => GetServerSideProps<P & ApiLinkProps>;
+
+const withAPIBaseLink: WithAPIBaseLink = (getServerSidePropsFunc) => async (context) => {
+	const API_BASE_LINK =
+		process.env.APP_ENV === "production" ? "https://center-be.stamford.dev" : "https://center-be-beta.stamford.dev";
+
+	let props: GetServerSidePropsResult<any> = { props: {} };
+
+	if (getServerSidePropsFunc) {
+		props = await getServerSidePropsFunc(context);
+	}
+
+	// Ensure props is an object with a props key
+	if ("props" in props) {
+		return {
+			props: {
+				...props.props,
+				API_BASE_LINK,
+			},
+		};
+	}
+
+	return props;
+};
+
+export default withAPIBaseLink;


### PR DESCRIPTION
This pull request replaces the usage of the constant API_BASE_LINK with a proper implementation that takes into account the environment (production or beta). This ensures that the correct API base link is used in each environment. The changes are made in the files ResourcesPage.tsx and StudyPlansPage.tsx. Additionally, a new utility function withAPIBaseLink is added to handle the API base link logic.